### PR TITLE
Fix bulk CC/BCC handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ sender.send_bulk(
 ).unwrap();
 ```
 
+Each recipient receives its own email, and any addresses provided in `cc` or
+`bcc` are included on every message.
+
 ---
 
 ## Environment Variables

--- a/src/email_sender.rs
+++ b/src/email_sender.rs
@@ -247,15 +247,12 @@ impl EmailSender {
         for rcpt in &recipients {
             info!("Bulk sending to {}", rcpt);
 
-            let cc_iter = cc.as_ref().and_then(|cc_vec| cc_vec.get(0).cloned().map(std::iter::once));
-            let bcc_iter = bcc.as_ref().and_then(|bcc_vec| bcc_vec.get(0).cloned().map(std::iter::once));
-
             self.send(
-                std::iter::once(rcpt.clone()),
+                vec![rcpt.clone()],
                 subject,
                 body,
-                cc_iter,
-                bcc_iter,
+                cc.clone(),
+                bcc.clone(),
                 attachments,
                 use_tls,
                 html,


### PR DESCRIPTION
## Summary
- include all CC and BCC addresses when using `send_bulk`
- document bulk CC/BCC behavior
- fix compile error by passing a `Vec` in `send_bulk`