### PR TITLE
Handle address parsing errors

### DIFF
--- a/src/email_sender.rs
+++ b/src/email_sender.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use lettre::AsyncTransport;
 use lettre::message::{header, Attachment, Mailbox, Message, MultiPart, SinglePart};
+use lettre::address::AddressError;
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{AsyncSmtpTransport, SmtpTransport, Tokio1Executor, Transport};
 use log::{error, info, warn};
@@ -22,6 +23,8 @@ pub enum MailkitError {
     Tera(#[from] tera::Error),
     #[error("Build message error: {0}")]
     Build(#[from] lettre::error::Error),
+    #[error("Address parse error: {0}")]
+    Address(#[from] AddressError),
     #[error("Missing environment variable: {0}")]
     MissingEnvVar(&'static str),
 }


### PR DESCRIPTION
## Summary
- support `lettre::address::AddressError` in `MailkitError`

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*
- `cargo test` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68450a505284832fa94c56e9500e27f1