### PR TITLE
Remove email_address dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,10 +207,7 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -344,9 +341,6 @@ name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "env_filter"
@@ -760,18 +754,14 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 name = "mailkit"
 version = "0.1.0"
 dependencies = [
- "chrono",
- "email_address",
  "env_logger",
  "lettre",
  "log",
- "mime",
  "serde",
  "serde_json",
  "tera",
  "thiserror",
  "tokio",
- "validator",
 ]
 
 [[package]]
@@ -1527,21 +1517,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "validator"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
-dependencies = [
- "idna",
- "once_cell",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
-]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,6 @@ tokio = { version = "1.45.1", features = ["full"] }
 tera = "1.20.0"
 log = "0.4.27"
 env_logger = "0.11.8"
-validator = "0.20.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-chrono = { version = "0.4.41", features = ["serde"] }
-mime = "0.3.17"
 thiserror = "2.0.12"
-email_address = "0.2.9"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Website: [rambod.net](https://rambod.net)
 - Environment variable configuration for secrets
 - CC/BCC
 - Bulk sending
-- Input email validation
+- Input email validation (built-in, no external crate)
+- Minimal dependencies
 - Fully customizable
 - **No IMAP support (by design for now)**
 
@@ -27,7 +28,6 @@ Website: [rambod.net](https://rambod.net)
 
 - lettre
 - tera
-- email_address
 - thiserror
 - log, env_logger (optional)
 - serde, serde_json (for templates)
@@ -39,7 +39,6 @@ Website: [rambod.net](https://rambod.net)
 ```toml
 lettre = { version = "0.11", features = ["smtp-transport", "tokio1"] }
 tera = "1.17"
-email_address = "0.2"
 thiserror = "1.0"
 log = "0.4"
 env_logger = "0.9"

--- a/src/email_sender.rs
+++ b/src/email_sender.rs
@@ -8,7 +8,6 @@ use lettre::transport::smtp::authentication::Credentials;
 use lettre::{AsyncSmtpTransport, SmtpTransport, Tokio1Executor, Transport};
 use log::{error, info, warn};
 use tera::{Context, Tera};
-use email_address::EmailAddress;
 
 #[derive(Debug, thiserror::Error)]
 pub enum MailkitError {
@@ -85,7 +84,16 @@ impl EmailSender {
     }
 
     fn check_email(addr: &str) -> Result<String, MailkitError> {
-        if EmailAddress::is_valid(addr) {
+        fn is_valid_email(addr: &str) -> bool {
+            let mut parts = addr.split('@');
+            if let (Some(local), Some(domain), None) = (parts.next(), parts.next(), parts.next()) {
+                !local.is_empty() && !domain.is_empty() && domain.contains('.')
+            } else {
+                false
+            }
+        }
+
+        if is_valid_email(addr) {
             Ok(addr.to_lowercase())
         } else {
             error!("Invalid email address: {}", addr);


### PR DESCRIPTION
## Summary
- drop unused crates and stop using `email_address`
- implement simple validator directly in `EmailSender`
- note minimal dependencies and new validation in README

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6845617c0024832fb4802e2ad6721f0a