### PR TITLE
Remove env_logger and add SimpleLogger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,56 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,12 +194,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,29 +285,6 @@ name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
-
-[[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "fastrand"
@@ -637,40 +558,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jiff"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "js-sys"
@@ -754,7 +645,6 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 name = "mailkit"
 version = "0.1.0"
 dependencies = [
- "env_logger",
  "lettre",
  "log",
  "serde",
@@ -827,12 +717,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "parking_lot"
@@ -966,21 +850,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1510,12 +1379,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,5 @@ lettre = { version = "0.11.17", default-features = false, features = ["builder",
 tokio = { version = "1.45.1", features = ["full"] }
 tera = "1.20.0"
 log = "0.4.27"
-env_logger = "0.11.8"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Website: [rambod.net](https://rambod.net)
 
 - lettre
 - tera
-- log, env_logger (optional)
+- log (with built-in simple logger)
 - serde, serde_json (for templates)
 
 ## Quick Start
@@ -39,7 +39,6 @@ Website: [rambod.net](https://rambod.net)
 lettre = { version = "0.11", features = ["smtp-transport", "tokio1"] }
 tera = "1.17"
 log = "0.4"
-env_logger = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ```
@@ -47,7 +46,7 @@ serde_json = "1.0"
 ### 2. Example Usage
 
 ```rust
-use mailkit::EmailSender;
+use mailkit::{EmailSender, SimpleLogger};
 use std::env;
 
 env::set_var("EMAIL", "your@email.com");
@@ -55,6 +54,7 @@ env::set_var("EMAIL_PASSWORD", "yourpassword");
 env::set_var("SMTP_SERVER", "smtp.yourprovider.com");
 env::set_var("SMTP_PORT", "587");
 
+SimpleLogger::init().unwrap();
 let sender = EmailSender::from_env().unwrap();
 
 sender.send(
@@ -127,7 +127,7 @@ Each recipient receives its own email, and any addresses provided in `cc` or
 
 ## Logging
 
-- Uses `log` crate. Set up `env_logger` for debugging.
+- Uses the `log` crate. Call `mailkit::SimpleLogger::init()` to enable basic logging.
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod email_sender;
+pub mod simple_logger;
 
 pub use email_sender::{EmailSender, SendAgent};
+pub use simple_logger::SimpleLogger;

--- a/src/simple_logger.rs
+++ b/src/simple_logger.rs
@@ -1,0 +1,37 @@
+use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};
+use std::sync::OnceLock;
+
+pub struct SimpleLogger {
+    level: LevelFilter,
+}
+
+impl Log for SimpleLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= self.level
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            println!("[{}] {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+impl SimpleLogger {
+    pub fn init() -> Result<(), SetLoggerError> {
+        static LOGGER: OnceLock<SimpleLogger> = OnceLock::new();
+        let level = match std::env::var("RUST_LOG").as_deref() {
+            Ok("trace") => LevelFilter::Trace,
+            Ok("debug") => LevelFilter::Debug,
+            Ok("warn") => LevelFilter::Warn,
+            Ok("error") => LevelFilter::Error,
+            _ => LevelFilter::Info,
+        };
+        let logger = LOGGER.get_or_init(|| SimpleLogger { level });
+        log::set_logger(logger)?;
+        log::set_max_level(level);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- drop `env_logger` dependency
- add a built-in `SimpleLogger`
- export `SimpleLogger` from the library
- document how to enable logging in README