### PR TITLE
Support CC/BCC iterators in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ sender.send_template(
     "welcome.html",    // Path inside ./templates/
     &tera_ctx,
     None,              // CC
+    None,              // BCC
     None,              // Attachments
     false
 ).unwrap();


### PR DESCRIPTION
## Summary
- accept CC/BCC iterators in `send_template`
- propagate CC/BCC to `send`
- update README example