### PR TITLE
Fix json macro key parsing

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -72,9 +72,14 @@ macro_rules! json {
     (null) => {
         $crate::json::JsonValue::Null
     };
-    ({$($key:tt : $value:tt),* $(,)?}) => {{
+    ({$($key:literal : $value:tt),* $(,)?}) => {{
         let mut map = std::collections::BTreeMap::new();
         $( map.insert($key.to_string(), $crate::json!($value)); )*
+        $crate::json::JsonValue::Object(map)
+    }};
+    ({$($key:ident : $value:tt),* $(,)?}) => {{
+        let mut map = std::collections::BTreeMap::new();
+        $( map.insert(stringify!($key).to_string(), $crate::json!($value)); )*
         $crate::json::JsonValue::Object(map)
     }};
     ([$($elem:tt),* $(,)?]) => {

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -16,3 +16,14 @@ fn macro_array() {
     let val = mailkit::json!([1u64, 2u64, 3u64]);
     assert_eq!(val, JsonValue::Array(vec![JsonValue::Number(1.0), JsonValue::Number(2.0), JsonValue::Number(3.0)]));
 }
+
+#[test]
+fn macro_object_ident() {
+    let val = mailkit::json!({a: 1u64, b: true});
+    if let JsonValue::Object(map) = val {
+        assert_eq!(map.get("a"), Some(&JsonValue::Number(1.0)));
+        assert_eq!(map.get("b"), Some(&JsonValue::Bool(true)));
+    } else {
+        panic!("not object");
+    }
+}


### PR DESCRIPTION
## Summary
- support identifier keys in `json!` macro
- add regression tests