### PR TITLE
Use mime_guess for attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "lettre",
+ "mime_guess",
  "serde",
  "serial_test",
  "tera",
@@ -733,6 +734,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1444,6 +1455,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ tokio = { version = "1.45.1", features = ["full"] }
 tera = "1.20.0"
 serde = { version = "1.0.219", features = ["derive"] }
 futures = "0.3"
+mime_guess = "2"
 
 [dev-dependencies]
 serial_test = "2.0"

--- a/src/email_sender.rs
+++ b/src/email_sender.rs
@@ -15,6 +15,7 @@ use lettre::AsyncTransport;
 use lettre::message::{Attachment, Mailbox, Message, MultiPart, SinglePart};
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{AsyncSmtpTransport, SmtpTransport, Tokio1Executor, Transport};
+use mime_guess;
 use tera::{Context, Tera};
 
 use std::error::Error as StdError;
@@ -239,7 +240,7 @@ impl EmailSender {
         Ok(builder)
     }
 
-    fn attach_files(
+    pub fn attach_files(
         &self,
         multipart: MultiPart,
         attachments: &[String],
@@ -251,7 +252,8 @@ impl EmailSender {
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or("attachment");
-            let ctype = lettre::message::header::ContentType::parse("application/octet-stream")
+            let mime = mime_guess::from_path(path).first_or_octet_stream();
+            let ctype = lettre::message::header::ContentType::parse(mime.essence_str())
                 .map_err(|_| MailkitError::Validation("Invalid content type".into()))?;
             let attachment = Attachment::new(filename.to_string())
                 .body(data, ctype);
@@ -260,7 +262,7 @@ impl EmailSender {
         Ok(mp)
     }
 
-    async fn attach_files_async(
+    pub async fn attach_files_async(
         &self,
         multipart: MultiPart,
         attachments: &[String],
@@ -272,7 +274,8 @@ impl EmailSender {
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or("attachment");
-            let ctype = lettre::message::header::ContentType::parse("application/octet-stream")
+            let mime = mime_guess::from_path(path).first_or_octet_stream();
+            let ctype = lettre::message::header::ContentType::parse(mime.essence_str())
                 .map_err(|_| MailkitError::Validation("Invalid content type".into()))?;
             let attachment = Attachment::new(filename.to_string())
                 .body(data, ctype);

--- a/tests/email_sender.rs
+++ b/tests/email_sender.rs
@@ -65,6 +65,52 @@ fn from_env_valid() {
     assert!(res.is_ok());
 }
 
+#[test]
+#[serial]
+fn attach_txt_content_type() {
+    use lettre::message::MultiPart;
+    set_var("MAILKIT_TEMPLATE_DIR", "tests/templates");
+    let sender = EmailSender::new(
+        "user@example.com",
+        "smtp.example.com",
+        "password",
+        25,
+        1,
+        true,
+    )
+    .unwrap();
+
+    let mp = MultiPart::mixed().build();
+    let mp = sender
+        .attach_files(mp, &["tests/files/sample.txt".to_string()])
+        .unwrap();
+    let body = String::from_utf8(mp.formatted()).unwrap();
+    assert!(body.contains("Content-Type: text/plain"));
+}
+
+#[tokio::test]
+async fn attach_html_content_type_async() {
+    use lettre::message::MultiPart;
+    set_var("MAILKIT_TEMPLATE_DIR", "tests/templates");
+    let sender = EmailSender::new(
+        "user@example.com",
+        "smtp.example.com",
+        "password",
+        25,
+        1,
+        true,
+    )
+    .unwrap();
+
+    let mp = MultiPart::mixed().build();
+    let mp = sender
+        .attach_files_async(mp, &["tests/files/sample.html".to_string()])
+        .await
+        .unwrap();
+    let body = String::from_utf8(mp.formatted()).unwrap();
+    assert!(body.contains("Content-Type: text/html"));
+}
+
 /// This test will actually send a real email using Gmail SMTP.
 /// You must fill in your real credentials and recipient!
 #[ignore]

--- a/tests/files/sample.html
+++ b/tests/files/sample.html
@@ -1,0 +1,1 @@
+<html><body>Hello</body></html>

--- a/tests/files/sample.txt
+++ b/tests/files/sample.txt
@@ -1,0 +1,1 @@
+Just a text file.


### PR DESCRIPTION
## Summary
- add `mime_guess` crate
- detect attachment content type with `mime_guess`
- expose attachment helpers for testing
- test `.txt` and `.html` attachment types